### PR TITLE
Feature/improve editor

### DIFF
--- a/frontend/src/features/article/ArticleEditor.tsx
+++ b/frontend/src/features/article/ArticleEditor.tsx
@@ -1,5 +1,5 @@
 import { Button, Flex, Tabs } from '@mantine/core'
-import { useMediaQuery } from '@mantine/hooks'
+import { useMediaQuery, useDebouncedState } from '@mantine/hooks'
 import {
   IconPhoto,
   IconMessageCircle,
@@ -12,7 +12,6 @@ import { Editor, Preview } from '.'
 
 type Mode = 'edit' | 'preview' | 'live'
 type EditorState = 'clean' | 'dirty' | 'saving' | 'saved'
-
 type Props = {
   body: string
   onSave: (v: string) => void
@@ -20,11 +19,11 @@ type Props = {
 }
 
 export const ArticleEditor: FC<Props> = ({ body, onSave, onDelete }) => {
-  const [markdown, setMarkdown] = useState(body)
+  // setの間隔が500ms以上で、debouncedに反映される
+  const [markdown, setMarkdown] = useDebouncedState(body, 500)
   const [mode, setMode] = useState<Mode>('live')
-
-  // 保存できない dirty saving saved
   const [editorState, setEditorState] = useState<EditorState>('clean')
+  const isMdScreen = useMediaQuery('(min-width: 768px)')
 
   const onClickSave = useCallback(async () => {
     if (editorState !== 'dirty') return
@@ -36,9 +35,7 @@ export const ArticleEditor: FC<Props> = ({ body, onSave, onDelete }) => {
     setTimeout(() => {
       setEditorState('clean')
     }, 2000)
-  }, [editorState, markdown, onSave])
-
-  const isMdScreen = useMediaQuery('(min-width: 768px)')
+  }, [markdown, editorState, onSave])
 
   return (
     <div>
@@ -71,8 +68,8 @@ export const ArticleEditor: FC<Props> = ({ body, onSave, onDelete }) => {
       >
         <div className={`${mode === 'preview' && 'hidden'}`}>
           <Editor
-            markdown={markdown}
-            setMarkdown={setMarkdown}
+            body={body}
+            setMarkdown={(v: string) => setMarkdown(v)}
             onSave={onClickSave}
             onDirty={() => setEditorState('dirty')}
           />

--- a/frontend/src/features/article/ArticleEditor.tsx
+++ b/frontend/src/features/article/ArticleEditor.tsx
@@ -47,13 +47,11 @@ export const ArticleEditor: FC<Props> = ({ body, onSave, onDelete }) => {
         <div className={`${mode === 'preview' && 'hidden'}`}>
           <Editor markdown={markdown} setMarkdown={setMarkdown} />
         </div>
-        <div
-          className={`h-[calc(100vh-290px)] overflow-y-auto ${
-            mode === 'edit' && 'hidden'
-          } ${mode === 'live' && 'hidden md:block'}`}
-        >
-          <Preview markdown={markdown} />
-        </div>
+        {/* preview、liveでmd以上の時表示する */}
+        {(mode === 'preview' || (mode === 'live' && isMdScreen)) && (
+          <div className='h-[calc(100vh-290px)] overflow-y-auto'>
+            <Preview markdown={markdown} />
+          </div>
       </div>
 
       <Flex mt='sm' gap='sm' justify='end'>

--- a/frontend/src/features/article/Editor.tsx
+++ b/frontend/src/features/article/Editor.tsx
@@ -1,45 +1,47 @@
 import dynamic from 'next/dynamic'
-import { FC, SetStateAction } from 'react'
+import { FC, useState } from 'react'
 
 import { usePasteImage } from './usePasteImage'
 const MDEditor = dynamic(() => import('@uiw/react-md-editor'), { ssr: false })
 
 type Props = {
-  markdown: string
-  setMarkdown: (v: SetStateAction<string>) => void
+  body?: string
   onSave?: () => void
   onDirty?: () => void
+  setMarkdown?: (v: string) => void
 }
 export const Editor: FC<Props> = ({
-  markdown,
-  setMarkdown,
+  body = '',
   onSave,
   onDirty,
+  setMarkdown,
 }) => {
+  const [text, setText] = useState(body)
   const { pasteImage } = usePasteImage()
 
   return (
     <div>
       <div data-color-mode='light' className='h-[calc(100vh-290px)] '>
         <MDEditor
-          value={markdown}
+          value={text}
           onChange={value => {
-            setMarkdown(value || '')
+            setText(value || '')
+            setMarkdown?.(value || '')
             onDirty?.()
           }}
           height='100%'
           textareaProps={{
-            placeholder: 'Fill in your markdown for the coolest of the cool.',
+            placeholder: 'Fill in your text for the coolest of the cool.',
           }}
           hideToolbar
           preview='edit'
           onPaste={async e => {
-            await pasteImage(e.clipboardData, setMarkdown)
+            await pasteImage(e.clipboardData, setText)
             // 範囲選択していたら、リンク追加処理もする
           }}
           onDrop={async e => {
             e.preventDefault() // 画像を別タブで表示しない
-            await pasteImage(e.dataTransfer, setMarkdown)
+            await pasteImage(e.dataTransfer, setText)
           }}
           onKeyDown={e => {
             if (e.ctrlKey && e.code === 'KeyS') {

--- a/frontend/src/features/article/Editor.tsx
+++ b/frontend/src/features/article/Editor.tsx
@@ -7,8 +7,15 @@ const MDEditor = dynamic(() => import('@uiw/react-md-editor'), { ssr: false })
 type Props = {
   markdown: string
   setMarkdown: (v: SetStateAction<string>) => void
+  onSave?: () => void
+  onDirty?: () => void
 }
-export const Editor: FC<Props> = ({ markdown, setMarkdown }) => {
+export const Editor: FC<Props> = ({
+  markdown,
+  setMarkdown,
+  onSave,
+  onDirty,
+}) => {
   const { pasteImage } = usePasteImage()
 
   return (
@@ -18,6 +25,7 @@ export const Editor: FC<Props> = ({ markdown, setMarkdown }) => {
           value={markdown}
           onChange={value => {
             setMarkdown(value || '')
+            onDirty?.()
           }}
           height='100%'
           textareaProps={{
@@ -32,6 +40,13 @@ export const Editor: FC<Props> = ({ markdown, setMarkdown }) => {
           onDrop={async e => {
             e.preventDefault() // 画像を別タブで表示しない
             await pasteImage(e.dataTransfer, setMarkdown)
+          }}
+          onKeyDown={e => {
+            if (e.ctrlKey && e.code === 'KeyS') {
+              e.preventDefault()
+              onSave?.()
+              console.log('Controlボンバー')
+            }
           }}
         />
       </div>

--- a/frontend/src/features/article/Preview.tsx
+++ b/frontend/src/features/article/Preview.tsx
@@ -13,8 +13,6 @@ export const Preview: FC<Props> = ({ markdown }) => {
 
   const [windowReady, setWindowReady] = useState(false)
 
-  console.log('preview')
-
   useEffect(() => {
     import('zenn-embed-elements')
     setWindowReady(true)

--- a/frontend/src/features/article/Preview.tsx
+++ b/frontend/src/features/article/Preview.tsx
@@ -1,4 +1,4 @@
-import Head from 'next/head'
+import Script from 'next/script'
 import { FC, useEffect, useState } from 'react'
 import markdownHtml from 'zenn-markdown-html'
 import 'zenn-content-css'
@@ -13,6 +13,8 @@ export const Preview: FC<Props> = ({ markdown }) => {
 
   const [windowReady, setWindowReady] = useState(false)
 
+  console.log('preview')
+
   useEffect(() => {
     import('zenn-embed-elements')
     setWindowReady(true)
@@ -22,12 +24,7 @@ export const Preview: FC<Props> = ({ markdown }) => {
     <div className='mx-auto break-words'>
       {windowReady && (
         <>
-          <Head>
-            <script
-              async
-              src='https://embed.zenn.studio/js/listen-embed-event.js'
-            ></script>
-          </Head>
+          <Script src='https://embed.zenn.studio/js/listen-embed-event.js' />
           <div
             // zennのCSS
             className='znc'

--- a/frontend/src/pages/editor.tsx
+++ b/frontend/src/pages/editor.tsx
@@ -40,7 +40,7 @@ const Minio: NextPage = () => {
         }`}
       >
         <div className={`${mode === 'preview' && 'hidden'}`}>
-          <Editor markdown={markdown} setMarkdown={setMarkdown} />
+          <Editor body={markdown} setMarkdown={setMarkdown} />
         </div>
         <div
           className={`max-h-[calc(100vh-140px)] overflow-y-auto ${


### PR DESCRIPTION
## 詳細
エディタの改善

- エディタの状態を4つ持ち、保存ボタンの文字と挙動を変更
  - clean　変更がない
  - dirty　変更がある
  - saving　保存中
  - saved　保存済み

- Editorのモードがeditor, liveでスマホの時、Previewを表示しない
  - 再レンダリングを防ぐ
- エディタの状態をEdiorコンポーネントで持ち、打ち終わって500ms経ったらPreviewに反映するようにする
- <script>を<Script>コンポーネントに変更


## 動作確認

![CPT2307021209-650x308](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/2a568589-8d1d-49bb-9bf8-25c61a5ff981)

![CPT2307021558-938x804](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/6fe227a5-b7a4-47a7-9bad-040745a3311d)
