### PR TITLE
fix: エディタで画像をアップロードするとき、Previewに反映させる

### DIFF
--- a/frontend/src/features/article/Editor.tsx
+++ b/frontend/src/features/article/Editor.tsx
@@ -36,12 +36,20 @@ export const Editor: FC<Props> = ({
           hideToolbar
           preview='edit'
           onPaste={async e => {
-            await pasteImage(e.clipboardData, setText)
+            await pasteImage(e.clipboardData, (v: string) => {
+              setText(v)
+              setMarkdown?.(v)
+            })
+            onDirty?.()
             // 範囲選択していたら、リンク追加処理もする
           }}
           onDrop={async e => {
             e.preventDefault() // 画像を別タブで表示しない
-            await pasteImage(e.dataTransfer, setText)
+            await pasteImage(e.dataTransfer, (v: string) => {
+              setText(v)
+              setMarkdown?.(v)
+            })
+            onDirty?.()
           }}
           onKeyDown={e => {
             if (e.ctrlKey && e.code === 'KeyS') {

--- a/frontend/src/features/article/usePasteImage.ts
+++ b/frontend/src/features/article/usePasteImage.ts
@@ -1,4 +1,4 @@
-import { useCallback, type SetStateAction } from 'react'
+import { useCallback } from 'react'
 
 import { useUploadFile } from '@/hooks/useUploadFile'
 
@@ -17,6 +17,7 @@ const insertToTextArea = (insertString: string) => {
 
   sentence = front + insertString + back
 
+  // 複数ペーストする際に必要
   textarea.value = sentence
   textarea.selectionEnd = end + insertString.length
 
@@ -31,10 +32,7 @@ export const usePasteImage = () => {
   const { uploadFile } = useUploadFile()
 
   const pasteImage = useCallback(
-    async (
-      dataTransfer: DataTransfer,
-      setMarkdown: (v: SetStateAction<string>) => void,
-    ) => {
+    async (dataTransfer: DataTransfer, setValue: (v: string) => void) => {
       // 複数の画像のペーストにも対応
       const files: File[] = []
       for (let index = 0; index < dataTransfer.items.length; index++) {
@@ -46,7 +44,7 @@ export const usePasteImage = () => {
       await Promise.all(
         files.map(async file => {
           const url = (await uploadFile(file)) || ''
-          setMarkdown(insertToTextArea(`![](${url})`))
+          setValue(insertToTextArea(`![](${url})`))
         }),
       )
     },


### PR DESCRIPTION
## 詳細
- 前回の変更で、Editorをdebouncedにしたので、エディタに画像をアップロードするときにPreviewに反映されないバグが発生していた
- なので、エディタで画像をアップロードするとき、Previewに反映させる

## 動作確認

![CPT2307041533-978x626](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/936071cf-8e62-475e-8706-562a965b4bd0)
