### PR TITLE
リクエストスキーマ名修正、スキーマの型をfeature/typesで定義する

### DIFF
--- a/frontend/src/features/article/ArticleEditor.tsx
+++ b/frontend/src/features/article/ArticleEditor.tsx
@@ -9,7 +9,7 @@ type Mode = 'edit' | 'preview' | 'live'
 type EditorState = 'clean' | 'dirty' | 'saving' | 'saved'
 type Props = {
   body: string
-  onSave: (v: string) => void
+  onSave: (markdown: string) => void
   onDelete: () => void
 }
 

--- a/frontend/src/features/article/useArticle.ts
+++ b/frontend/src/features/article/useArticle.ts
@@ -16,7 +16,7 @@ export const useCreateArticle = (sectionId: string) => {
   const createArticle = useCallback(async () => {
     try {
       const newArticle = await postApi<Article>('/articles', {
-        body: 'ここに記事をマークダウン形式で書きます',
+        body: '// ここに記事をマークダウン形式で書きます',
         sectionId,
       })
       console.log('追加に成功', newArticle)

--- a/frontend/src/features/course/components/CourseForm.tsx
+++ b/frontend/src/features/course/components/CourseForm.tsx
@@ -11,18 +11,17 @@ import {
 import { IconAlertCircle } from '@tabler/icons-react'
 import { ChangeEvent, FC, useCallback, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
-import { z } from 'zod'
 
 import { useFormErrorHandling } from '@/hooks/useFormErrorHandling'
 import { useUploadFile } from '@/hooks/useUploadFile'
-import { courseSchema } from '@/libs/validates'
+import { courseRequestSchema } from '@/libs/validates'
 
-export type CourseFormRequest = z.infer<typeof courseSchema>
+import { CourseRequest } from '../types'
 
 type Props = {
-  onSubmit: (params: CourseFormRequest) => void
+  onSubmit: (params: CourseRequest) => void
   submitButtonName?: string
-  initValue?: CourseFormRequest
+  initValue?: CourseRequest
   onDirty: () => void
 }
 
@@ -37,14 +36,14 @@ export const CourseForm: FC<Props> = ({
     handleSubmit,
     setValue,
     formState: { errors, isDirty },
-  } = useForm<CourseFormRequest>({
-    resolver: zodResolver(courseSchema),
+  } = useForm<CourseRequest>({
+    resolver: zodResolver(courseRequestSchema),
     criteriaMode: 'all',
     defaultValues: initValue ?? { imageUrl: '' },
   })
 
   const { onSubmit, errorMessage, clearErrorMessage } =
-    useFormErrorHandling<CourseFormRequest>(onSubmitProps)
+    useFormErrorHandling<CourseRequest>(onSubmitProps)
 
   // useEffectを使わないと、レンダリング中にsetStateを呼ぶことになりWarningが出る
   useEffect(() => {

--- a/frontend/src/features/course/components/CreateCourseButton.tsx
+++ b/frontend/src/features/course/components/CreateCourseButton.tsx
@@ -3,10 +3,11 @@ import { FC } from 'react'
 
 import { useModalForm } from '@/hooks/useModalForm'
 
-import { CourseForm, CourseFormRequest } from './CourseForm'
+import { CourseForm } from './CourseForm'
+import { CourseRequest } from '../types'
 
 type Props = {
-  onSubmit: (params: CourseFormRequest) => void
+  onSubmit: (params: CourseRequest) => void
 }
 
 export const CreateCourseButton: FC<Props> = ({ onSubmit: onSubmitProps }) => {

--- a/frontend/src/features/course/components/UpdateCourseButton.tsx
+++ b/frontend/src/features/course/components/UpdateCourseButton.tsx
@@ -3,11 +3,12 @@ import { FC } from 'react'
 
 import { useModalForm } from '@/hooks/useModalForm'
 
-import { CourseForm, CourseFormRequest } from './CourseForm'
+import { CourseForm } from './CourseForm'
+import { CourseRequest } from '../types'
 
 type Props = {
-  onSubmit: (params: CourseFormRequest) => void
-  initValue: CourseFormRequest
+  onSubmit: (params: CourseRequest) => void
+  initValue: CourseRequest
 }
 
 export const UpdateCourseButton: FC<Props> = ({

--- a/frontend/src/features/course/hooks/useCourse.ts
+++ b/frontend/src/features/course/hooks/useCourse.ts
@@ -4,14 +4,14 @@ import { useCallback } from 'react'
 import { useGetApi } from '@/hooks/useApi'
 import { postApi, putApi, deleteApi } from '@/utils/api'
 
-import { CourseFormRequest } from '../'
+import { CourseRequest } from '../types'
 
 export const useCreateCourse = () => {
   const { data: courses, mutate: mutateCourses } =
     useGetApi<Course[]>('/courses')
 
   const createCourse = useCallback(
-    async (params: CourseFormRequest) => {
+    async (params: CourseRequest) => {
       try {
         const newCourse = await postApi<Course>('/courses', params)
         console.log('追加に成功', newCourse)
@@ -38,7 +38,7 @@ export const useUpdateCourse = () => {
     useGetApi<Course[]>('/courses')
 
   const updateCourse = useCallback(
-    async (id: string, params: CourseFormRequest) => {
+    async (id: string, params: CourseRequest) => {
       try {
         const updatedCourse = await putApi<Course>(`/courses/${id}`, params)
         console.log('更新に成功', updatedCourse)

--- a/frontend/src/features/course/index.ts
+++ b/frontend/src/features/course/index.ts
@@ -1,4 +1,3 @@
-export type { CourseFormRequest } from './components/CourseForm'
 export * from './components/CreateCourseButton'
 export * from './components/UpdateCourseButton'
 export * from './hooks/useCourse'

--- a/frontend/src/features/course/types.ts
+++ b/frontend/src/features/course/types.ts
@@ -1,5 +1,9 @@
 import { Article, Course, Quiz, Section, UserAgent } from '@prisma/client'
+import { z } from 'zod'
 
+import { courseRequestSchema } from '@/libs/validates'
+
+// TODO: 直下のtypesに移動
 export type CourseWithSections = Course & {
   sections: (Section & {
     userAgent: UserAgent | null
@@ -7,3 +11,5 @@ export type CourseWithSections = Course & {
     quizzes: Quiz[]
   })[]
 }
+
+export type CourseRequest = z.infer<typeof courseRequestSchema>

--- a/frontend/src/features/quiz/QuizForm.tsx
+++ b/frontend/src/features/quiz/QuizForm.tsx
@@ -19,12 +19,11 @@ import {
 } from '@tabler/icons-react'
 import { FC, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { z } from 'zod'
 
 import { useFormErrorHandling } from '@/hooks/useFormErrorHandling'
 import { quizFormRequestSchema } from '@/libs/validates'
 
-export type QuizFormRequest = z.infer<typeof quizFormRequestSchema>
+import { QuizFormRequest } from './types'
 
 type Props = {
   onSubmit: (params: QuizFormRequest) => void

--- a/frontend/src/features/quiz/QuizFormModalButton.tsx
+++ b/frontend/src/features/quiz/QuizFormModalButton.tsx
@@ -3,7 +3,9 @@ import { FC } from 'react'
 
 import { useModalForm } from '@/hooks/useModalForm'
 
-import { QuizForm, QuizFormRequest } from './'
+import { QuizFormRequest } from './types'
+
+import { QuizForm } from './'
 
 type Props = {
   onSubmit: (params: QuizFormRequest) => void

--- a/frontend/src/features/quiz/index.ts
+++ b/frontend/src/features/quiz/index.ts
@@ -1,3 +1,4 @@
 export * from './QuizForm'
 export * from './QuizFormModalButton'
 export * from './useQuiz'
+export * from './types'

--- a/frontend/src/features/quiz/types.ts
+++ b/frontend/src/features/quiz/types.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+
+import { quizFormRequestSchema } from '@/libs/validates'
+
+export type QuizFormRequest = z.infer<typeof quizFormRequestSchema>

--- a/frontend/src/features/quiz/useQuiz.ts
+++ b/frontend/src/features/quiz/useQuiz.ts
@@ -4,9 +4,8 @@ import { useCallback } from 'react'
 import { useGetApi } from '@/hooks/useApi'
 import { postApi, putApi, deleteApi } from '@/utils/api'
 
+import { QuizFormRequest } from './types'
 import { SectionWithRelation } from '../section'
-
-import { QuizFormRequest } from './'
 
 // sectionのmutate
 export const useCreateQuiz = (sectionId: string) => {

--- a/frontend/src/features/section/components/CreateSectionButton.tsx
+++ b/frontend/src/features/section/components/CreateSectionButton.tsx
@@ -3,7 +3,8 @@ import { FC } from 'react'
 
 import { useModalForm } from '@/hooks/useModalForm'
 
-import { SectionForm, SectionFormRequest } from './SectionForm'
+import { SectionForm } from './SectionForm'
+import { SectionFormRequest } from '../types'
 
 type Props = {
   onSubmit: (params: SectionFormRequest) => void

--- a/frontend/src/features/section/components/SectionForm.tsx
+++ b/frontend/src/features/section/components/SectionForm.tsx
@@ -25,15 +25,12 @@ import type {
   UseFormSetValue,
   UseFormClearErrors,
 } from 'react-hook-form'
-import { z } from 'zod'
 
 import { useGetApi } from '@/hooks/useApi'
 import { useFormErrorHandling } from '@/hooks/useFormErrorHandling'
 import { sectionFormRequestSchema } from '@/libs/validates'
 
-export type SectionFormRequest = z.infer<typeof sectionFormRequestSchema>
-
-type SectionType = 'quiz' | 'article' | 'sandbox'
+import { SectionFormRequest } from '../types'
 
 type Props = {
   onSubmit: (params: SectionFormRequest) => void

--- a/frontend/src/features/section/components/SectionItem.tsx
+++ b/frontend/src/features/section/components/SectionItem.tsx
@@ -8,9 +8,8 @@ import {
 import Link from 'next/link'
 import { FC } from 'react'
 
-import { SectionFormRequest } from './SectionForm'
 import { UpdateSectionButton } from './UpdateSectionButton'
-import { SectionWithRelation } from '../types'
+import { SectionFormRequest, SectionWithRelation } from '../types'
 
 type Props = {
   courseId: string

--- a/frontend/src/features/section/components/UpdateSectionButton.tsx
+++ b/frontend/src/features/section/components/UpdateSectionButton.tsx
@@ -3,7 +3,8 @@ import { FC } from 'react'
 
 import { useModalForm } from '@/hooks/useModalForm'
 
-import { SectionForm, SectionFormRequest } from './SectionForm'
+import { SectionForm } from './SectionForm'
+import { SectionFormRequest } from '../types'
 
 type Props = {
   onSubmit: (params: SectionFormRequest) => void

--- a/frontend/src/features/section/index.ts
+++ b/frontend/src/features/section/index.ts
@@ -1,4 +1,3 @@
-export type { SectionFormRequest } from './components/SectionForm'
 export * from './components/CreateSectionButton'
 export * from './components/UpdateSectionButton'
 export * from './components/DraggableSections'

--- a/frontend/src/features/section/types.ts
+++ b/frontend/src/features/section/types.ts
@@ -1,7 +1,12 @@
 import { UserAgent, Section, Article, Quiz } from '@prisma/client'
+import { z } from 'zod'
+
+import { sectionFormRequestSchema } from '@/libs/validates'
 
 export type SectionWithRelation = Section & {
   userAgent: UserAgent | null
   articles: Article[]
   quizzes: Quiz[]
 }
+
+export type SectionFormRequest = z.infer<typeof sectionFormRequestSchema>

--- a/frontend/src/features/section/useSection.ts
+++ b/frontend/src/features/section/useSection.ts
@@ -4,8 +4,7 @@ import { useCallback } from 'react'
 import { useGetApi } from '@/hooks/useApi'
 import { deleteApi, postApi, putApi } from '@/utils/api'
 
-import { SectionFormRequest } from './components/SectionForm'
-import { SectionWithRelation } from './types'
+import { SectionFormRequest, SectionWithRelation } from './types'
 import { CourseWithSections } from '../course'
 
 // 作成

--- a/frontend/src/features/userAgent/components/CreateUserAgentButton.tsx
+++ b/frontend/src/features/userAgent/components/CreateUserAgentButton.tsx
@@ -3,7 +3,8 @@ import { FC } from 'react'
 
 import { useModalForm } from '@/hooks/useModalForm'
 
-import { UserAgentFormRequest, UserAgentForm } from './UserAgentForm'
+import { UserAgentForm } from './UserAgentForm'
+import { UserAgentFormRequest } from '../types'
 
 type Props = {
   onSubmit: (params: UserAgentFormRequest) => void

--- a/frontend/src/features/userAgent/components/UpdateUserAgentButton.tsx
+++ b/frontend/src/features/userAgent/components/UpdateUserAgentButton.tsx
@@ -3,7 +3,8 @@ import { FC } from 'react'
 
 import { useModalForm } from '@/hooks/useModalForm'
 
-import { UserAgentForm, UserAgentFormRequest } from './UserAgentForm'
+import { UserAgentForm } from './UserAgentForm'
+import { UserAgentFormRequest } from '../types'
 
 type Props = {
   onSubmit: (params: UserAgentFormRequest) => void

--- a/frontend/src/features/userAgent/components/UserAgentForm.tsx
+++ b/frontend/src/features/userAgent/components/UserAgentForm.tsx
@@ -3,12 +3,11 @@ import { Alert, Button, Flex, Select, Stack, TextInput } from '@mantine/core'
 import { IconAlertCircle } from '@tabler/icons-react'
 import { FC, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
-import { z } from 'zod'
 
 import { useFormErrorHandling } from '@/hooks/useFormErrorHandling'
-import { userAgentSchema } from '@/libs/validates'
+import { userAgentRequestSchema } from '@/libs/validates'
 
-export type UserAgentFormRequest = z.infer<typeof userAgentSchema>
+import { UserAgentFormRequest } from '../types'
 
 type Props = {
   onSubmit: (params: UserAgentFormRequest) => void
@@ -30,7 +29,7 @@ export const UserAgentForm: FC<Props> = ({
     clearErrors,
     formState: { errors, isDirty },
   } = useForm<UserAgentFormRequest>({
-    resolver: zodResolver(userAgentSchema),
+    resolver: zodResolver(userAgentRequestSchema),
     criteriaMode: 'all',
     defaultValues: initValue,
   })

--- a/frontend/src/features/userAgent/index.ts
+++ b/frontend/src/features/userAgent/index.ts
@@ -1,4 +1,4 @@
-export type { UserAgentFormRequest } from './components/UserAgentForm'
 export * from './components/CreateUserAgentButton'
 export * from './components/UpdateUserAgentButton'
 export * from './useUserAgent'
+export * from './types'

--- a/frontend/src/features/userAgent/types.ts
+++ b/frontend/src/features/userAgent/types.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+
+import { userAgentRequestSchema } from '@/libs/validates'
+
+export type UserAgentFormRequest = z.infer<typeof userAgentRequestSchema>

--- a/frontend/src/features/userAgent/useUserAgent.ts
+++ b/frontend/src/features/userAgent/useUserAgent.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react'
 import { useGetApi } from '@/hooks/useApi'
 import { postApi, putApi, deleteApi } from '@/utils/api'
 
-import { UserAgentFormRequest } from '.'
+import { UserAgentFormRequest } from './types'
 
 export const useCreateUserAgent = () => {
   const { data: userAgents, mutate: mutateUserAgents } =

--- a/frontend/src/libs/validates/article.ts
+++ b/frontend/src/libs/validates/article.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-export const articleSchema = z.object({
+export const articleRequestSchema = z.object({
   body: z
     .string({ required_error: '本文は必須です' })
     .nonempty('本文は必須です'),
@@ -9,4 +9,6 @@ export const articleSchema = z.object({
     .nonempty('セクションが選択されていません'),
 })
 
-export const articleUpdateSchema = articleSchema.pick({ body: true })
+export const articleUpdateRequestSchema = articleRequestSchema.pick({
+  body: true,
+})

--- a/frontend/src/libs/validates/course.ts
+++ b/frontend/src/libs/validates/course.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 // "" | cms-storageのimagesバケット内のオブジェクトURL
 const imageUrlRegex = new RegExp('^(https://cms-storage.cypas.sec/images/.+|)$')
 
-export const courseSchema = z.object({
+export const courseRequestSchema = z.object({
   name: z
     .string()
     .nonempty('コース名は必須です')
@@ -24,7 +24,7 @@ export const courseSchema = z.object({
 })
 
 // sectionIdsを追加して全プロパティをオプショナルに
-export const courseUpdateSchema = courseSchema
+export const courseUpdateRequestSchema = courseRequestSchema
   .extend({
     sectionIds: z.array(z.string().nonempty('空のsectionIdがあります')),
   })

--- a/frontend/src/libs/validates/quiz.ts
+++ b/frontend/src/libs/validates/quiz.ts
@@ -40,12 +40,14 @@ const sectionIdSchema = z
   .string({ required_error: 'セクションは必須です' })
   .nonempty('セクションは必須です')
 
-export const quizSchema = z.union([
+// APiへのリクエストはquizRequestSchema
+export const quizRequestSchema = z.union([
   textSchema.extend({ sectionId: sectionIdSchema }),
   radioSchema.extend({ sectionId: sectionIdSchema }),
   checkboxSchema.extend({ sectionId: sectionIdSchema }),
 ])
 
+// フォームのリクエストはquizFormRequestSchema
 export const quizFormRequestSchema = z.union([
   textSchema,
   radioSchema,

--- a/frontend/src/libs/validates/section.ts
+++ b/frontend/src/libs/validates/section.ts
@@ -36,7 +36,10 @@ const sectionSandboxSchema = z.object({
 
 const courseIdSchema = z.string().nonempty('コースが選択されていません')
 
-export const sectionSchema = z.union([
+// APiへのリクエストはsectionRequestSchema
+// フォームのリクエストはsectionFormRequestSchema
+// カスタムフックでsectionFormRequestSchemaに、courseIdを追加してAPIへリクエストする
+export const sectionRequestSchema = z.union([
   sectionQuizSchema.extend({ courseId: courseIdSchema }),
   sectionArticleSchema.extend({ courseId: courseIdSchema }),
   sectionSandboxSchema.extend({ courseId: courseIdSchema }),
@@ -63,34 +66,8 @@ const sectionSandboxUpdateSchema = sectionSandboxSchema.extend({
     .optional(),
 })
 
-export const sectionUpdateSchema = z.union([
+export const sectionUpdateRequestSchema = z.union([
   sectionQuizUpdateSchema,
   sectionArticleUpdateSchema,
   sectionSandboxUpdateSchema,
 ])
-
-// quizIds以外のquiz, quizIds含めたquiz ,... 6パターンのみ許可するスキーマ
-
-// type Update = z.infer<typeof sectionUpdateSchema>
-
-// const article: Update = { type: 'article', name: 'f' }
-// const articleWithArticleIds: Update = {
-//   type: 'article',
-//   name: 'f',
-//   articleIds: ['f'],
-// }
-// const quiz: Update = { type: 'quiz', name: 'f' }
-// const quizWithQuizIds: Update = { type: 'quiz', name: 'f', quizIds: ['f'] }
-// const sandbox: Update = {
-//   type: 'sandbox',
-//   name: 'f',
-//   scenarioGitHubUrl: '',
-//   userAgentId: 'a',
-// }
-// const sandboxWithArticleIds: Update = {
-//   type: 'sandbox',
-//   name: 'f',
-//   userAgentId: 'f',
-//   scenarioGitHubUrl: '',
-//   articleIds: ['f'],
-// }

--- a/frontend/src/libs/validates/userAgent.ts
+++ b/frontend/src/libs/validates/userAgent.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { gitHubUrlRegex } from './section'
 
-export const userAgentSchema = z.object({
+export const userAgentRequestSchema = z.object({
   name: z.string().nonempty('ユーザーエージェント名は必須です'),
   gitHubUrl: z
     .string()

--- a/frontend/src/pages/api/articles/[id].ts
+++ b/frontend/src/pages/api/articles/[id].ts
@@ -1,8 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import prisma from '@/libs/prisma'
-import { apiValidation } from '@/libs/validates'
-import { articleUpdateSchema } from '@/libs/validates/article'
+import { apiValidation, articleUpdateRequestSchema } from '@/libs/validates'
 
 export default async function handler(
   req: NextApiRequest,
@@ -27,7 +26,7 @@ export default async function handler(
       break
 
     case 'PUT':
-      apiValidation(req, res, articleUpdateSchema, async () => {
+      apiValidation(req, res, articleUpdateRequestSchema, async () => {
         const updatedArticle = await prisma.article.update({
           where: {
             id: id,

--- a/frontend/src/pages/api/articles/index.ts
+++ b/frontend/src/pages/api/articles/index.ts
@@ -1,8 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import prisma from '@/libs/prisma'
-import { apiValidation } from '@/libs/validates'
-import { articleSchema } from '@/libs/validates/article'
+import { apiValidation, articleRequestSchema } from '@/libs/validates'
 
 export default async function handler(
   req: NextApiRequest,
@@ -24,7 +23,7 @@ export default async function handler(
       break
 
     case 'POST':
-      apiValidation(req, res, articleSchema, async () => {
+      apiValidation(req, res, articleRequestSchema, async () => {
         const createdArticle = await prisma.article.create({
           data: {
             body: body.body,

--- a/frontend/src/pages/api/courses/[id].ts
+++ b/frontend/src/pages/api/courses/[id].ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import prisma from '@/libs/prisma'
-import { apiValidation, courseUpdateSchema } from '@/libs/validates'
+import { apiValidation, courseUpdateRequestSchema } from '@/libs/validates'
 
 export default async function handler(
   req: NextApiRequest,
@@ -37,7 +37,7 @@ export default async function handler(
       break
 
     case 'PUT':
-      apiValidation(req, res, courseUpdateSchema, async () => {
+      apiValidation(req, res, courseUpdateRequestSchema, async () => {
         const updatedCourse = await prisma.course.update({
           where: {
             id: id,

--- a/frontend/src/pages/api/courses/index.ts
+++ b/frontend/src/pages/api/courses/index.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import prisma from '@/libs/prisma'
-import { apiValidation, courseSchema } from '@/libs/validates'
+import { apiValidation, courseRequestSchema } from '@/libs/validates'
 
 export default async function handler(
   req: NextApiRequest,
@@ -34,7 +34,7 @@ export default async function handler(
       break
 
     case 'POST':
-      apiValidation(req, res, courseSchema, async () => {
+      apiValidation(req, res, courseRequestSchema, async () => {
         const createdCourse = await prisma.course.create({
           data: {
             name: body.name,

--- a/frontend/src/pages/api/quizzes/[id].ts
+++ b/frontend/src/pages/api/quizzes/[id].ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import prisma from '@/libs/prisma'
-import { apiValidation, quizSchema } from '@/libs/validates'
+import { apiValidation, quizRequestSchema } from '@/libs/validates'
 
 export default async function handler(
   req: NextApiRequest,
@@ -26,7 +26,7 @@ export default async function handler(
       break
 
     case 'PUT':
-      apiValidation(req, res, quizSchema, async () => {
+      apiValidation(req, res, quizRequestSchema, async () => {
         const updatedArticle = await prisma.quiz.update({
           where: {
             id: id,

--- a/frontend/src/pages/api/quizzes/index.ts
+++ b/frontend/src/pages/api/quizzes/index.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import prisma from '@/libs/prisma'
-import { apiValidation, quizSchema } from '@/libs/validates'
+import { apiValidation, quizRequestSchema } from '@/libs/validates'
 
 export default async function handler(
   req: NextApiRequest,
@@ -23,7 +23,7 @@ export default async function handler(
       break
 
     case 'POST':
-      apiValidation(req, res, quizSchema, async () => {
+      apiValidation(req, res, quizRequestSchema, async () => {
         const createdArticle = await prisma.quiz.create({
           data: {
             question: body.question,

--- a/frontend/src/pages/api/sections/[id].ts
+++ b/frontend/src/pages/api/sections/[id].ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import prisma from '@/libs/prisma'
-import { apiValidation, sectionUpdateSchema } from '@/libs/validates'
+import { apiValidation, sectionUpdateRequestSchema } from '@/libs/validates'
 
 export default async function handler(
   req: NextApiRequest,
@@ -32,7 +32,7 @@ export default async function handler(
 
     case 'PUT':
       // 全部オプショナルなら、違うtypeの値入ってもzod通しちゃう
-      apiValidation(req, res, sectionUpdateSchema, async () => {
+      apiValidation(req, res, sectionUpdateRequestSchema, async () => {
         const sectionRequest: {
           name: string
           type: string

--- a/frontend/src/pages/api/sections/index.ts
+++ b/frontend/src/pages/api/sections/index.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import prisma from '@/libs/prisma'
-import { apiValidation, sectionSchema } from '@/libs/validates'
+import { apiValidation, sectionRequestSchema } from '@/libs/validates'
 
 export default async function handler(
   req: NextApiRequest,
@@ -30,7 +30,7 @@ export default async function handler(
 
     // typeで3つに分ける？
     case 'POST':
-      apiValidation(req, res, sectionSchema, async () => {
+      apiValidation(req, res, sectionRequestSchema, async () => {
         const sectionRequest: {
           name: string
           type: string

--- a/frontend/src/pages/api/useragents/[id].ts
+++ b/frontend/src/pages/api/useragents/[id].ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import prisma from '@/libs/prisma'
-import { apiValidation, userAgentSchema } from '@/libs/validates'
+import { apiValidation, userAgentRequestSchema } from '@/libs/validates'
 
 export default async function handler(
   req: NextApiRequest,
@@ -26,7 +26,7 @@ export default async function handler(
       break
 
     case 'PUT':
-      apiValidation(req, res, userAgentSchema, async () => {
+      apiValidation(req, res, userAgentRequestSchema, async () => {
         const updatedUserAgent = await prisma.userAgent.update({
           where: {
             id: id,

--- a/frontend/src/pages/api/useragents/index.ts
+++ b/frontend/src/pages/api/useragents/index.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import prisma from '@/libs/prisma'
-import { apiValidation, userAgentSchema } from '@/libs/validates'
+import { apiValidation, userAgentRequestSchema } from '@/libs/validates'
 
 export default async function handler(
   req: NextApiRequest,
@@ -23,7 +23,7 @@ export default async function handler(
       break
 
     case 'POST':
-      apiValidation(req, res, userAgentSchema, async () => {
+      apiValidation(req, res, userAgentRequestSchema, async () => {
         const createdUserAgent = await prisma.userAgent.create({
           data: {
             name: body.name,

--- a/frontend/src/pages/articles/[id].tsx
+++ b/frontend/src/pages/articles/[id].tsx
@@ -12,8 +12,6 @@ const ArticlePage: NextPage = () => {
 
   const { data: article } = useGetApi<Article>(`/articles/${id}`)
 
-  console.log('article: ', article)
-
   if (!article || !id) {
     return (
       <div className='h-screen grid place-items-center'>

--- a/frontend/src/pages/courses/[courseId]/index.tsx
+++ b/frontend/src/pages/courses/[courseId]/index.tsx
@@ -15,9 +15,9 @@ import {
   useUpdateCourseSectionOrder,
   useUpdateSection,
   SectionItem,
+  SectionFormRequest,
 } from '@/features/section'
 import { useGetApi } from '@/hooks/useApi'
-import { SectionFormRequest } from '@/libs/validates'
 
 const Courses: NextPage = () => {
   const [draggableMode, setDraggableMode] = useState(false)

--- a/frontend/src/pages/courses/[courseId]/index.tsx
+++ b/frontend/src/pages/courses/[courseId]/index.tsx
@@ -10,7 +10,6 @@ import { CourseWithSections } from '@/features/course'
 import {
   CreateSectionButton,
   DraggableSections,
-  SectionFormRequest,
   useCreateSection,
   useDeleteSection,
   useUpdateCourseSectionOrder,
@@ -18,6 +17,7 @@ import {
   SectionItem,
 } from '@/features/section'
 import { useGetApi } from '@/hooks/useApi'
+import { SectionFormRequest } from '@/libs/validates'
 
 const Courses: NextPage = () => {
   const [draggableMode, setDraggableMode] = useState(false)

--- a/frontend/src/pages/courses/index.tsx
+++ b/frontend/src/pages/courses/index.tsx
@@ -13,8 +13,8 @@ import {
   useUpdateCourse,
   useDeleteCourse,
   CourseWithSections,
-  CourseFormRequest,
   UpdateCourseButton,
+  CourseRequest,
 } from '@/features/course'
 import { useGetApi } from '@/hooks/useApi'
 import { convertToJapanTime } from '@/utils/convertToJapanTime'
@@ -117,7 +117,7 @@ const Courses: NextPage = () => {
         enableSorting: false,
         maxSize: 0,
         Cell: ({ row: { original: course } }) => {
-          const courseFormRequest: CourseFormRequest = {
+          const courseFormRequest: CourseRequest = {
             name: course.name,
             level: course.level as 1 | 2 | 3,
             description: course.description ?? '',


### PR DESCRIPTION
## 詳細
- schema名変える courseSchema ⇒ courseRequestSchema
    - schemaは直下に置くのでOK。apiも参照するから
- ドメイン内のtypesファイルにschemaの型を定義
    - Formコンポーネントで定義した型を、あちこちで使いたくないので、feature/course/typesで定義する

## 動作確認
