### PR TITLE
パンくずリストの実装

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -85,14 +85,6 @@
             "from": ["src/features/*/!(index.ts)", "src/features/*/*/**"],
             "target": "src/pages/**"
           },
-          // componentsはpages|componentsのみ
-          {
-            "from": "**/components/**",
-            "target": [
-              "src/!(pages|features)/**",
-              "src/features/*/!(components)/**"
-            ]
-          },
           // 直下componentsが、featuresはダメ
           {
             "from": "src/features/*/components/**",

--- a/frontend/src/components/BreadCrumbs.tsx
+++ b/frontend/src/components/BreadCrumbs.tsx
@@ -1,0 +1,28 @@
+import { Breadcrumbs as DefaultBreadcrumbs } from '@mantine/core'
+import Link from 'next/link'
+import { FC, useMemo } from 'react'
+
+export type Item = { title: string; href: string }
+
+type Props = {
+  items: Item[]
+}
+
+export const BreadCrumbs: FC<Props> = ({ items }) => {
+  const breadcrumbsItems = useMemo(() => {
+    return items.map((item, i) => {
+      // 最後の要素はLinkにしない
+      if (i === items.length - 1) {
+        return <p key={item.title}>{item.title}</p>
+      }
+
+      return (
+        <Link href={item.href} key={item.title}>
+          {item.title}
+        </Link>
+      )
+    })
+  }, [items])
+
+  return <DefaultBreadcrumbs>{breadcrumbsItems}</DefaultBreadcrumbs>
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,12 +2,15 @@ import Head from 'next/head'
 import Link from 'next/link'
 import { FC, ReactNode } from 'react'
 
+import { BreadCrumbs, type Item as breadCrumbsitem } from './BreadCrumbs'
+
 type Props = {
   children: ReactNode
   title?: string
+  breadcrumbItems?: breadCrumbsitem[]
 }
 
-export const Layout: FC<Props> = ({ title, children }) => {
+export const Layout: FC<Props> = ({ title, children, breadcrumbItems }) => {
   return (
     <>
       <Head>
@@ -26,7 +29,15 @@ export const Layout: FC<Props> = ({ title, children }) => {
         </nav>
       </header>
 
-      <main className='my-6 mx-4'>{children}</main>
+      <main className='my-6 mx-4'>
+        {breadcrumbItems && (
+          <div className='mb-4 overflow-x-auto overflow-y-hidden'>
+            <BreadCrumbs items={breadcrumbItems} />
+          </div>
+        )}
+
+        {children}
+      </main>
     </>
   )
 }

--- a/frontend/src/pages/courses/[courseId]/[sectionId]/index.tsx
+++ b/frontend/src/pages/courses/[courseId]/[sectionId]/index.tsx
@@ -1,3 +1,4 @@
+import { Course } from '@prisma/client'
 import { NextPage } from 'next'
 import { useSearchParams } from 'next/navigation'
 
@@ -9,9 +10,13 @@ import { SectionWithRelation } from '@/types'
 const Courses: NextPage = () => {
   const searchParams = useSearchParams()
   const sectionId = searchParams.get('sectionId') || ''
+  const courseId = searchParams.get('courseId') || ''
+
   const { data: section } = useGetApi<SectionWithRelation>(
     `/sections/${sectionId}`,
   )
+
+  const { data: course } = useGetApi<Course>(`/courses/${courseId}`)
 
   if (!section || !sectionId) {
     return (
@@ -21,14 +26,22 @@ const Courses: NextPage = () => {
     )
   }
 
+  const courseTitleName = course
+    ? `${course.name}のセクション一覧`
+    : 'セクション一覧'
+
+  const typeName = section.type === 'quiz' ? '問題一覧' : '記事一覧'
+  const titleName = `${section.name}の${typeName}`
+
   return (
-    <Layout>
-      <h1>
-        {section.name}
-        {section.type === 'quiz' && 'の問題一覧'}
-        {section.type === 'article' && 'の記事一覧'}
-        {section.type === 'sandbox' && 'の記事一覧'}
-      </h1>
+    <Layout
+      breadcrumbItems={[
+        { title: 'コース一覧', href: '/courses' },
+        { title: courseTitleName, href: `/courses/${courseId}` },
+        { title: titleName, href: '' },
+      ]}
+    >
+      <h1>{titleName}</h1>
       <div>
         {section.type === 'quiz' && (
           <div>

--- a/frontend/src/pages/courses/[courseId]/index.tsx
+++ b/frontend/src/pages/courses/[courseId]/index.tsx
@@ -63,7 +63,12 @@ const Courses: NextPage = () => {
   }
 
   return (
-    <Layout>
+    <Layout
+      breadcrumbItems={[
+        { title: 'コース一覧', href: '/courses' },
+        { title: `${course.name}のセクション一覧`, href: '' },
+      ]}
+    >
       <h1>{course.name}のセクション一覧</h1>
       <div>
         {!draggableMode.v && (


### PR DESCRIPTION
## 詳細

レイアウトは、Mantineの[Breadcrumbs](https://mantine.dev/core/breadcrumbs/)をラップして使用
パンくずリスト自身にマージンを付けず、共通の見た目にしたいので、Layoutコンポーネント内で表示する。

以下のページにパンくずリストを表示する
- コース詳細ページ（セクション一覧）
- セクション詳細ページ（Article, Quiz, Sandbox）


## 動作確認

![image](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/8df64fce-b48f-4338-a816-3d2637baaf33)


![image](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/e1fa643b-f0a6-4079-b52c-db9993da9d0a)

