### PR TITLE
JSONファイルアップロードでコースを作成

### DIFF
--- a/frontend/src/components/ExportJsonButton.tsx
+++ b/frontend/src/components/ExportJsonButton.tsx
@@ -1,4 +1,4 @@
-import { IconDownload } from '@tabler/icons-react'
+import { IconUpload } from '@tabler/icons-react'
 import { FC } from 'react'
 
 type Props = {
@@ -14,9 +14,9 @@ export const ExportJsonButton: FC<Props> = ({ data, fileName }) => {
   const jsonURL = URL.createObjectURL(blobData)
 
   return (
-    <a href={jsonURL} download={fileNameWithJson} className='flex'>
-      エクスポート
-      <IconDownload size='1.5rem' className='cursor-pointer' />
+    <a href={jsonURL} download={fileNameWithJson} className='flex gap-2'>
+      <IconUpload size='1.5rem' />
+      <span>エクスポート</span>
     </a>
   )
 }

--- a/frontend/src/features/course/components/CourseFileInput.tsx
+++ b/frontend/src/features/course/components/CourseFileInput.tsx
@@ -1,0 +1,90 @@
+import { FileInput, Loader } from '@mantine/core'
+import {
+  IconCircleCheck,
+  IconDownload,
+  IconExclamationMark,
+} from '@tabler/icons-react'
+import { FC, useCallback, useMemo, useState } from 'react'
+
+import { CourseWithSections } from '@/types'
+
+type FileInputState = 'default' | 'loading' | 'saved' | 'error'
+type Props = { createWithRelationCourse: (params: CourseWithSections) => void }
+
+export const CourseFileInput: FC<Props> = ({ createWithRelationCourse }) => {
+  const [fileInputStatus, setFileInputStatus] =
+    useState<FileInputState>('default')
+
+  const createCourseWithRelation = useCallback(
+    async (params: CourseWithSections) => {
+      try {
+        setFileInputStatus('loading')
+        await createWithRelationCourse(params)
+        setFileInputStatus('saved')
+
+        setTimeout(() => {
+          setFileInputStatus('default')
+        }, 2000)
+      } catch (err) {
+        setFileInputStatus('error')
+        alert(err)
+        console.error(err)
+      }
+    },
+    [createWithRelationCourse],
+  )
+
+  const handleFileChange = useCallback(
+    async (file: File | null) => {
+      if (!file) return
+      const reader = new FileReader()
+
+      // ファイルの中身を解析
+      reader.onload = event => {
+        const content = event?.target?.result
+        try {
+          const jsonData: CourseWithSections = JSON.parse(content as string) // 中身をJSONパースする
+          createCourseWithRelation(jsonData) // 中身を元にコースを作成
+        } catch (error) {
+          alert(
+            `JSONファイルを解析できませんでした。\n内容を確認して再度お試しください。\n${error}`,
+          )
+          console.error(
+            'JSONファイルを解析できませんでした。\n内容を確認して再度お試しください。',
+            error,
+          )
+          return
+        }
+      }
+      reader.readAsText(file)
+    },
+    [createCourseWithRelation],
+  )
+
+  const fileInputIcon = useMemo(() => {
+    if (fileInputStatus === 'loading') return <Loader size='sm' color='gray' />
+    if (fileInputStatus === 'saved') return <IconCircleCheck color='green' />
+    if (fileInputStatus === 'error')
+      return (
+        <IconExclamationMark
+          color='red'
+          className='border rounded-full border-red-500'
+        />
+      )
+    return <IconDownload />
+  }, [fileInputStatus])
+
+  return (
+    <FileInput
+      placeholder='コースをインポート'
+      accept='.json'
+      icon={fileInputIcon}
+      classNames={{
+        placeholder: 'text-black',
+        icon: 'text-black',
+      }}
+      error={fileInputStatus === 'error' ? true : false}
+      onChange={handleFileChange}
+    />
+  )
+}

--- a/frontend/src/features/course/hooks/useCourse.ts
+++ b/frontend/src/features/course/hooks/useCourse.ts
@@ -91,3 +91,37 @@ export const useDeleteCourse = () => {
 
   return { deleteCourse }
 }
+
+export const useCreateCourseWithRelation = () => {
+  const { data: courses, mutate: mutateCourses } =
+    useGetApi<CourseWithSections[]>('/courses')
+
+  const createWithRelationCourse = useCallback(
+    async (params: CourseWithSections) => {
+      try {
+        const newCourse = await postApi<CourseWithSections>(
+          '/courses/bulk',
+          params,
+        )
+        console.log('追加に成功', newCourse)
+
+        if (!courses) return
+        // 再度データを取得しキャッシュを更新する
+        mutateCourses([...courses, newCourse])
+      } catch (e) {
+        console.error(e)
+        if (e instanceof Error) {
+          throw `コースの作成に失敗しました。\n以下が原因である可能性があるので、内容を確認し再度お試しください。\n
+- コースの名前(name)・制作者(author)・所属(organization)の組み合わせが既に存在する。
+- 必須項目が抜けている。
+- 項目の値に誤りがある。
+\n 以下はエラー内容です${e.message}`
+        }
+        throw JSON.stringify(e)
+      }
+    },
+    [courses, mutateCourses],
+  )
+
+  return { createWithRelationCourse }
+}

--- a/frontend/src/features/course/index.ts
+++ b/frontend/src/features/course/index.ts
@@ -1,4 +1,5 @@
 export * from './components/CreateCourseButton'
 export * from './components/UpdateCourseButton'
 export * from './components/CourseTable'
+export * from './components/CourseFileInput'
 export * from './hooks/useCourse'

--- a/frontend/src/libs/validates/course.ts
+++ b/frontend/src/libs/validates/course.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { sectionWithRelationSchema } from '.'
+import { sectionWithRelationSchema } from './section'
 
 // "" | cms-storageのimagesバケット内のオブジェクトURL
 const imageUrlRegex = new RegExp('^(https://cms-storage.cypas.sec/images/.+|)$')

--- a/frontend/src/libs/validates/course.ts
+++ b/frontend/src/libs/validates/course.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { sectionWithRelationSchema } from '.'
+
 // "" | cms-storageのimagesバケット内のオブジェクトURL
 const imageUrlRegex = new RegExp('^(https://cms-storage.cypas.sec/images/.+|)$')
 
@@ -29,3 +31,8 @@ export const courseUpdateRequestSchema = courseRequestSchema
     sectionIds: z.array(z.string().nonempty('空のsectionIdがあります')),
   })
   .partial()
+
+// リレーションもまとめて作成する
+export const courseWithRelationSchema = courseRequestSchema.extend({
+  sections: z.array(sectionWithRelationSchema),
+})

--- a/frontend/src/libs/validates/section.ts
+++ b/frontend/src/libs/validates/section.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod'
 
+import { quizFormRequestSchema } from './quiz'
+
+import { articleRequestSchema, userAgentRequestSchema } from '.'
+
 // "" | GitHubURL
 export const gitHubUrlRegex = new RegExp('^(https://github.com/.+|)$')
 
@@ -70,4 +74,14 @@ export const sectionUpdateRequestSchema = z.union([
   sectionQuizUpdateSchema,
   sectionArticleUpdateSchema,
   sectionSandboxUpdateSchema,
+])
+
+// リレーションもまとめて作成する
+export const sectionWithRelationSchema = z.union([
+  sectionQuizSchema.extend({ quizzes: z.array(quizFormRequestSchema) }),
+  sectionArticleSchema.extend({ articles: z.array(articleRequestSchema) }),
+  sectionSandboxSchema.extend({
+    articles: z.array(articleRequestSchema),
+    userAgent: userAgentRequestSchema,
+  }),
 ])

--- a/frontend/src/libs/validates/section.ts
+++ b/frontend/src/libs/validates/section.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod'
 
+import { articleRequestSchema } from './article'
 import { quizFormRequestSchema } from './quiz'
-
-import { articleRequestSchema, userAgentRequestSchema } from '.'
+import { userAgentRequestSchema } from './userAgent'
 
 // "" | GitHubURL
 export const gitHubUrlRegex = new RegExp('^(https://github.com/.+|)$')

--- a/frontend/src/libs/validates/section.ts
+++ b/frontend/src/libs/validates/section.ts
@@ -2,10 +2,8 @@ import { z } from 'zod'
 
 import { articleRequestSchema } from './article'
 import { quizFormRequestSchema } from './quiz'
+import { gitHubUrlRegex } from './shares'
 import { userAgentRequestSchema } from './userAgent'
-
-// "" | GitHubURL
-export const gitHubUrlRegex = new RegExp('^(https://github.com/.+|)$')
 
 // courseIdはcreateに必要だけど、formには要らない
 // formのdefaultでcourseIdだけ設定すればOK

--- a/frontend/src/libs/validates/shares.ts
+++ b/frontend/src/libs/validates/shares.ts
@@ -1,0 +1,2 @@
+// "" | GitHubURL
+export const gitHubUrlRegex = new RegExp('^(https://github.com/.+|)$')

--- a/frontend/src/libs/validates/userAgent.ts
+++ b/frontend/src/libs/validates/userAgent.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { gitHubUrlRegex } from './section'
+import { gitHubUrlRegex } from './shares'
 
 export const userAgentRequestSchema = z.object({
   name: z.string().nonempty('ユーザーエージェント名は必須です'),

--- a/frontend/src/pages/api/courses/bulk.ts
+++ b/frontend/src/pages/api/courses/bulk.ts
@@ -1,0 +1,101 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import { apiValidation, courseWithRelationSchema } from '@/libs/validates'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { method, body } = req
+
+  // api/courses
+  switch (method) {
+    case 'POST':
+      // OK bodyが返ってくる
+      // res.status(200).json({ data: body })
+      // return
+
+      // OK zod.parse通る
+      // apiValidation(req, res, courseRequestSchema, async () => {
+      //   res.status(200).json({ data: body })
+      // })
+      // return
+
+      // OK sections: []のJSONで試す
+      // sectionのQuiz入れて試す
+      apiValidation(req, res, courseWithRelationSchema, async () => {
+        res.status(200).json({ data: body })
+      })
+      break
+
+    default:
+      break
+  }
+}
+
+// try {
+// const ress = await prisma.course.create({
+//   data: {
+//     name: '沢山作るコース',
+//     description: '沢山作るコース',
+//     level: 1,
+//     imageUrl: 'http://沢山作るコース',
+//     author: '沢山作るコース',
+//     organization: '沢山作るコース',
+//     sections: {
+//       create: [
+//         {
+//           name: 'quizだよん',
+//           type: 'quiz',
+//           quizzes: {
+//             create: [
+//               {
+//                 question: '問題1',
+//                 type: 'radio',
+//                 choices: ['選択肢1', '選択肢2', '選択肢3'],
+//                 answers: ['選択肢2'],
+//                 explanation: '解説',
+//               },
+//             ],
+//           },
+//         },
+//         {
+//           name: 'articleだよん',
+//           type: 'article',
+//           articles: {
+//             create: [{ body: '## anpan' }],
+//           },
+//         },
+//         {
+//           name: 'sandboxだよん',
+//           type: 'sandbox',
+//           // TODO: userAgentの作成で、同じの沢山出来て失敗しそう
+//           // 事前にname, organization, authorで検索してあれば、connectにする？
+//           // それか、名前に乱数追加して被らないようにする
+//           userAgent: {
+//             create: {
+//               name: 'ユーザーエージェントだよん',
+//               author: 'わし',
+//               organization: 'わし',
+//               type: 'わし',
+//               gitHubUrl:
+//                 'https://github.com/shin-lab-sec/cypas-cms/pull/84/files',
+//             },
+//           },
+//         },
+//       ],
+//     },
+//   },
+// })
+// res.status(200).json({ data: ress })
+// } catch (err) {
+//   if (err instanceof Error) {
+//     res.status(400).json({ message: err.message })
+//     return
+//   }
+
+//   res
+//     .status(400)
+//     .json({ message: `Invalid request: ${JSON.stringify(err)}` })
+// }
+// res.status(405).end()

--- a/frontend/src/pages/api/courses/bulk.ts
+++ b/frontend/src/pages/api/courses/bulk.ts
@@ -5,196 +5,140 @@ import prisma from '@/libs/prisma'
 import { apiValidation, courseWithRelationSchema } from '@/libs/validates'
 import { SectionWithRelation } from '@/types'
 
+type CourseWithRelationRequest = Partial<Course> & {
+  sections?: { create: Partial<Section>[] }
+}
+
+type SectionWithRelationRequest = Partial<Section> & {
+  quizzes: { create: Partial<Quiz>[] }
+  articles: { create: Partial<Article>[] }
+  userAgent?: {
+    connectOrCreate: {
+      where: {
+        name_author_organization: Pick<
+          UserAgent,
+          'name' | 'author' | 'organization'
+        >
+      }
+      create: Partial<UserAgent>
+    }
+  }
+}
+
+// 既にUserAgentが存在すればconnect、無ければcreateする
+const generateUseragentRequest = (userAgent: UserAgent) => {
+  return {
+    userAgent: {
+      connectOrCreate: {
+        where: {
+          name_author_organization: {
+            name: userAgent.name,
+            author: userAgent.author,
+            organization: userAgent.organization,
+          },
+        },
+        create: {
+          name: userAgent.name,
+          gitHubUrl: userAgent.gitHubUrl,
+          type: userAgent.type,
+          author: userAgent.author,
+          organization: userAgent.organization,
+        },
+      },
+    },
+  }
+}
+
+const generateQuizzesRequest = (quizzes: Quiz[]) => {
+  return {
+    quizzes: {
+      create: quizzes.map(quiz => ({
+        question: quiz.question,
+        type: quiz.type,
+        choices: quiz.choices,
+        answers: quiz.answers,
+        explanation: quiz.explanation,
+      })),
+    },
+  }
+}
+
+const generateArticlesRequest = (articles: Article[]) => {
+  return {
+    articles: {
+      create: articles.map(article => ({
+        body: article.body,
+      })),
+    },
+  }
+}
+
+const generateSectionWithRelationRequest = (
+  sections: SectionWithRelation[],
+) => {
+  return sections.map(section => {
+    const quizzesRequest = generateQuizzesRequest(section.quizzes)
+    const articlesRequest = generateArticlesRequest(section.articles)
+    let userAgentRequest = {} // {}ならリクエストに含まれない
+
+    // userAgentがある時 既に存在すればconnect、無ければcreateする
+    if (section.userAgent) {
+      userAgentRequest = generateUseragentRequest(section.userAgent)
+    }
+
+    return {
+      name: section.name,
+      type: section.type,
+      scenarioGitHubUrl: section.scenarioGitHubUrl,
+      ...quizzesRequest,
+      ...articlesRequest,
+      ...userAgentRequest,
+    }
+  })
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  const { method, body } = req
+  const { body } = req
 
-  // api/courses
-  switch (method) {
-    case 'POST':
-      // OK bodyが返ってくる
-      // res.status(200).json({ data: body })
-      // return
+  // api/courses/bulk
+  apiValidation(req, res, courseWithRelationSchema, async () => {
+    let sectionsRequest = {}
 
-      // OK zod.parse通る
-      // apiValidation(req, res, courseRequestSchema, async () => {
-      //   res.status(200).json({ data: body })
-      // })
-      // return
+    // sectionがある時、sectionも同時に作成する
+    if (body.sections.length > 0) {
+      const sections = body.sections as SectionWithRelation[] // zodでparseしているのでSection[]でなければthrowする
+      const sectionsWithRelationRequest: SectionWithRelationRequest[] =
+        generateSectionWithRelationRequest(sections)
 
-      // OK sections: []のJSONで試す
-      // sectionのQuiz入れて試す
+      sectionsRequest = { sections: { create: sectionsWithRelationRequest } }
+    }
 
-      apiValidation(req, res, courseWithRelationSchema, async () => {
-        const courseWithRelationRequest: Partial<Course> & {
-          sections?: { create: Partial<Section>[] }
-        } = {
-          name: body.name,
-          description: body.description,
-          level: body.level,
-          imageUrl: body.imageUrl,
-          author: body.author,
-          organization: body.organization,
-          sectionIds: body.sectionIds,
-        }
+    const courseWithRelationRequest: CourseWithRelationRequest = {
+      name: body.name,
+      description: body.description,
+      level: body.level,
+      imageUrl: body.imageUrl,
+      author: body.author,
+      organization: body.organization,
+      sectionIds: body.sectionIds,
+      ...sectionsRequest, // {}ならリクエストに含まれない
+    }
 
-        // sectionsがある
-        if (body.sections.length > 0) {
-          const sections = body.sections as SectionWithRelation[] // zodでparseしているのでSection[]でなければthrowする
-
-          const sectionRequests: (Partial<Section> & {
-            quizzes: { create: Partial<Quiz>[] }
-            articles: { create: Partial<Article>[] }
-            userAgent?: {
-              connectOrCreate: {
-                where: {
-                  name_author_organization: Pick<
-                    UserAgent,
-                    'name' | 'author' | 'organization'
-                  >
-                }
-                create: Partial<UserAgent>
-              }
-            }
-          })[] = sections.map(section => {
-            let userAgent = {}
-
-            // userAgentがある時 存在すればconnect、無ければcreateする
-            if (section.userAgent) {
-              userAgent = {
-                userAgent: {
-                  connectOrCreate: {
-                    where: {
-                      name_author_organization: {
-                        name: section.userAgent.name,
-                        author: section.userAgent.author,
-                        organization: section.userAgent.organization,
-                      },
-                    },
-                    create: {
-                      name: section.userAgent.name,
-                      gitHubUrl: section.userAgent.gitHubUrl,
-                      type: section.userAgent.type,
-                      author: section.userAgent.author,
-                      organization: section.userAgent.organization,
-                    },
-                  },
-                },
-              }
-            }
-
-            return {
-              name: section.name,
-              type: section.type,
-              scenarioGitHubUrl: section.scenarioGitHubUrl,
-              quizzes: {
-                create: section.quizzes.map(quiz => ({
-                  question: quiz.question,
-                  type: quiz.type,
-                  choices: quiz.choices,
-                  answers: quiz.answers,
-                  explanation: quiz.explanation,
-                })),
-              },
-              articles: {
-                create: section.articles.map(article => ({
-                  body: article.body,
-                })),
-              },
-              // sandboxでない時は、userAgentを含めない
-              ...userAgent,
-            }
-          })
-
-          courseWithRelationRequest.sections = { create: sectionRequests }
-        }
-
-        const createdCourse = await prisma.course.create({
-          data: courseWithRelationRequest,
+    const createdCourse = await prisma.course.create({
+      data: courseWithRelationRequest as any, // courseWithRelationRequestに型を付けたかった
+      include: {
+        sections: {
           include: {
-            sections: {
-              include: {
-                userAgent: true,
-                articles: { orderBy: { createdAt: 'asc' } },
-                quizzes: { orderBy: { createdAt: 'asc' } },
-              },
-            },
+            userAgent: true,
+            articles: { orderBy: { createdAt: 'asc' } },
+            quizzes: { orderBy: { createdAt: 'asc' } },
           },
-        })
-        res.status(200).json({ data: createdCourse })
-      })
-      break
-
-    default:
-      break
-  }
+        },
+      },
+    })
+    res.status(200).json({ data: createdCourse })
+  })
 }
-
-// try {
-// const ress = await prisma.course.create({
-//   data: {
-//     name: '沢山作るコース',
-//     description: '沢山作るコース',
-//     level: 1,
-//     imageUrl: 'http://沢山作るコース',
-//     author: '沢山作るコース',
-//     organization: '沢山作るコース',
-//     sections: {
-//       create: [
-//         {
-//           name: 'quizだよん',
-//           type: 'quiz',
-//           quizzes: {
-//             create: [
-//               {
-//                 question: '問題1',
-//                 type: 'radio',
-//                 choices: ['選択肢1', '選択肢2', '選択肢3'],
-//                 answers: ['選択肢2'],
-//                 explanation: '解説',
-//               },
-//             ],
-//           },
-//         },
-//         {
-//           name: 'articleだよん',
-//           type: 'article',
-//           articles: {
-//             create: [{ body: '## anpan' }],
-//           },
-//         },
-//         {
-//           name: 'sandboxだよん',
-//           type: 'sandbox',
-//           // TODO: userAgentの作成で、同じの沢山出来て失敗しそう
-//           // 事前にname, organization, authorで検索してあれば、connectにする？
-//           // それか、名前に乱数追加して被らないようにする
-//           userAgent: {
-//             create: {
-//               name: 'ユーザーエージェントだよん',
-//               author: 'わし',
-//               organization: 'わし',
-//               type: 'わし',
-//               gitHubUrl:
-//                 'https://github.com/shin-lab-sec/cypas-cms/pull/84/files',
-//             },
-//           },
-//         },
-//       ],
-//     },
-//   },
-// })
-// res.status(200).json({ data: ress })
-// } catch (err) {
-//   if (err instanceof Error) {
-//     res.status(400).json({ message: err.message })
-//     return
-//   }
-
-//   res
-//     .status(400)
-//     .json({ message: `Invalid request: ${JSON.stringify(err)}` })
-// }
-// res.status(405).end()

--- a/frontend/src/pages/courses/index.tsx
+++ b/frontend/src/pages/courses/index.tsx
@@ -19,12 +19,44 @@ const Courses: NextPage = () => {
   const { updateCourse } = useUpdateCourse()
   const { deleteCourse } = useDeleteCourse()
 
+  const [fileContent, setFileContent] = useState(null)
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files || e.target.files.length === 0) {
+      console.error('JSONファイルを選択して下さい')
+      return
+    }
+
+    const file = e.target.files[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = event => {
+      const content = event?.target?.result
+      try {
+        const jsonData = JSON.parse(content as string)
+        setFileContent(jsonData)
+      } catch (error) {
+        console.error('JSONファイルを解析できませんでした。', error)
+      }
+    }
+    reader.readAsText(file)
+  }
+
   return (
     <Layout>
       <Flex gap='sm' justify='space-between' align='center'>
         <h1>コース一覧</h1>
         <CreateCourseButton onSubmit={createCourse} />
       </Flex>
+
+      <input type='file' accept='.json' onChange={handleFileChange} />
+      {fileContent && (
+        <div>
+          <h2>JSONデータ</h2>
+          <pre>{JSON.stringify(fileContent, null, 2)}</pre>
+        </div>
+      )}
 
       {courses?.length ? (
         <div className='mt-8'>

--- a/frontend/src/pages/courses/index.tsx
+++ b/frontend/src/pages/courses/index.tsx
@@ -1,5 +1,6 @@
-import { Flex } from '@mantine/core'
+import { Button, Flex } from '@mantine/core'
 import { NextPage } from 'next'
+import { ChangeEvent, useCallback, useState } from 'react'
 
 import { Layout } from '@/components/Layout'
 import {
@@ -11,6 +12,7 @@ import {
 } from '@/features/course'
 import { useGetApi } from '@/hooks/useApi'
 import { CourseWithSections } from '@/types'
+import { postApi } from '@/utils/api'
 
 const Courses: NextPage = () => {
   const { data: courses } = useGetApi<CourseWithSections[]>(`/courses`)
@@ -20,6 +22,18 @@ const Courses: NextPage = () => {
   const { deleteCourse } = useDeleteCourse()
 
   const [fileContent, setFileContent] = useState(null)
+
+  const createCourseWithRelation = useCallback(async () => {
+    try {
+      const res = await postApi('/courses/bulk', fileContent)
+      console.log('res: ', res)
+    } catch (err) {
+      if (err instanceof Error) {
+        console.error(err.message)
+        return
+      }
+    }
+  }, [fileContent])
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files || e.target.files.length === 0) {
@@ -48,12 +62,17 @@ const Courses: NextPage = () => {
       <Flex gap='sm' justify='space-between' align='center'>
         <h1>コース一覧</h1>
         <CreateCourseButton onSubmit={createCourse} />
+        <Button onClick={createCourseWithRelation}>インポートコース</Button>
       </Flex>
 
       <input type='file' accept='.json' onChange={handleFileChange} />
       {fileContent && (
         <div>
           <h2>JSONデータ</h2>
+          <p>
+            filename:
+            {fileContent.name}
+          </p>
           <pre>{JSON.stringify(fileContent, null, 2)}</pre>
         </div>
       )}

--- a/frontend/src/pages/courses/index.tsx
+++ b/frontend/src/pages/courses/index.tsx
@@ -1,4 +1,5 @@
-import { Button, Flex } from '@mantine/core'
+import { FileInput, Flex } from '@mantine/core'
+import { IconDownload } from '@tabler/icons-react'
 import { NextPage } from 'next'
 import { ChangeEvent, useCallback, useState } from 'react'
 
@@ -21,7 +22,7 @@ const Courses: NextPage = () => {
   const { updateCourse } = useUpdateCourse()
   const { deleteCourse } = useDeleteCourse()
 
-  const [fileContent, setFileContent] = useState(null)
+  const [fileContent, setFileContent] = useState<HTMLInputElement | null>(null)
 
   const createCourseWithRelation = useCallback(async () => {
     try {
@@ -35,7 +36,7 @@ const Courses: NextPage = () => {
     }
   }, [fileContent])
 
-  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files || e.target.files.length === 0) {
       console.error('JSONファイルを選択して下さい')
       return
@@ -55,24 +56,80 @@ const Courses: NextPage = () => {
       }
     }
     reader.readAsText(file)
-  }
+  }, [])
+  const handleFileChange2 = useCallback((file: File) => {
+    const reader = new FileReader()
+    reader.onload = event => {
+      const content = event?.target?.result
+      try {
+        const jsonData = JSON.parse(content as string)
+        setFileContent(jsonData)
+      } catch (error) {
+        console.error('JSONファイルを解析できませんでした。', error)
+      }
+    }
+    reader.readAsText(file)
+  }, [])
 
   return (
     <Layout>
       <Flex gap='sm' justify='space-between' align='center'>
         <h1>コース一覧</h1>
-        <CreateCourseButton onSubmit={createCourse} />
-        <Button onClick={createCourseWithRelation}>インポートコース</Button>
+        <Flex gap='sm' align='center'>
+          <FileInput
+            placeholder='コースをインポート'
+            accept='.json'
+            icon={<IconDownload />}
+            variant='unstyled'
+            classNames={{
+              placeholder: 'text-black',
+              icon: 'text-black',
+            }}
+            onChange={handleFileChange2}
+          />
+          <CreateCourseButton onSubmit={createCourse} />
+          {/* <Button onClick={createCourseWithRelation}>インポートコース</Button> */}
+
+          {/* <FileInput
+            placeholder='コースをインポート'
+            accept='.json'
+            icon={<IconDownload />}
+            classNames={{
+              root: 'border border-black rounded-md w-fit',
+              placeholder: 'text-black',
+              icon: 'text-black',
+            }}
+            onChange={handleFileChange2}
+          /> */}
+        </Flex>
       </Flex>
 
-      <input type='file' accept='.json' onChange={handleFileChange} />
+      {/* <input type='file' accept='.json' onChange={handleFileChange} /> */}
+
+      {/* <label htmlFor='file'>
+        <button className='flex items-center'>
+          コースをインポート
+          <IconDownload />
+        </button>
+      </label>
+
+      <label tabIndex={0}>
+        <span>コースをインポート</span>
+        <IconDownload />
+        <input
+          type='file'
+          id='file'
+          accept='.json'
+          onChange={handleFileChange}
+          // className='hidden'
+          className='opacity-0'
+        />
+      </label> */}
+
       {fileContent && (
         <div>
           <h2>JSONデータ</h2>
-          <p>
-            filename:
-            {fileContent.name}
-          </p>
+          <p>filename:</p>
           <pre>{JSON.stringify(fileContent, null, 2)}</pre>
         </div>
       )}

--- a/frontend/src/pages/courses/index.tsx
+++ b/frontend/src/pages/courses/index.tsx
@@ -1,11 +1,5 @@
-import { FileInput, Flex, Loader } from '@mantine/core'
-import {
-  IconCircleCheck,
-  IconDownload,
-  IconExclamationMark,
-} from '@tabler/icons-react'
+import { Flex } from '@mantine/core'
 import { NextPage } from 'next'
-import { useCallback, useMemo, useState } from 'react'
 
 import { Layout } from '@/components/Layout'
 import {
@@ -14,129 +8,27 @@ import {
   useUpdateCourse,
   useDeleteCourse,
   CourseTable,
+  CourseFileInput,
+  useCreateCourseWithRelation,
 } from '@/features/course'
 import { useGetApi } from '@/hooks/useApi'
 import { CourseWithSections } from '@/types'
-import { postApi } from '@/utils/api'
-
-// FIXME: cleanはdefaultでもいいかな？
-type FileInputState = 'clean' | 'saving' | 'saved' | 'error'
 
 const Courses: NextPage = () => {
-  const { data: courses, mutate: mutateCourses } =
-    useGetApi<CourseWithSections[]>(`/courses`)
-  const [fileInputStatus, setFileInputStatus] =
-    useState<FileInputState>('clean')
+  const { data: courses } = useGetApi<CourseWithSections[]>(`/courses`)
 
   const { createCourse } = useCreateCourse()
   const { updateCourse } = useUpdateCourse()
   const { deleteCourse } = useDeleteCourse()
-
-  const createCourseWithRelation = useCallback(
-    async (fileContent: any) => {
-      try {
-        setFileInputStatus('saving')
-        const res = await postApi<CourseWithSections>(
-          '/courses/bulk',
-          fileContent,
-        )
-
-        if (!courses) return
-        // 再度データを取得しキャッシュを更新する
-        mutateCourses([...courses, res])
-
-        setFileInputStatus('saved')
-
-        setTimeout(() => {
-          setFileInputStatus('clean')
-        }, 2000)
-
-        console.log('res: ', res)
-      } catch (err) {
-        if (err instanceof Error) {
-          alert(
-            `コースの作成に失敗しました。\n以下が原因である可能性があるので、内容を確認し再度お試しください。\n
-- コースの名前(name)・制作者(author)・所属(organization)の組み合わせが既に存在する。
-- 必須項目が抜けている。
-- 項目の値に誤りがある。
-\n 以下はエラー内容です${err.message}`,
-          )
-
-          console.error(
-            'コースの作成に失敗しました。\n',
-            '以下が原因である可能性があるので、内容を確認し再度お試しください。\n',
-            '- コースの名前(name)・制作者(author)・所属(organization)の組み合わせが既に存在する。\n',
-            '- 必須項目が抜けている。\n',
-            '- 項目の値に誤りがある。\n\n',
-            '以下はエラー内容です\n',
-            err.message,
-          ),
-            setFileInputStatus('error')
-
-          return
-        }
-      }
-    },
-    [courses, mutateCourses],
-  )
-
-  const handleFileChange = useCallback(
-    async (file: File | null) => {
-      if (!file) return
-      const reader = new FileReader()
-
-      // ファイルの中身を解析
-      reader.onload = event => {
-        const content = event?.target?.result
-        try {
-          const jsonData = JSON.parse(content as string) // 中身をJSONパースする
-          createCourseWithRelation(jsonData) // 中身を元にコースを作成
-        } catch (error) {
-          alert(
-            `JSONファイルを解析できませんでした。\n内容を確認して再度お試しください。\n${error}`,
-          )
-          console.error(
-            'JSONファイルを解析できませんでした。\n内容を確認して再度お試しください。',
-            error,
-          )
-          return
-        }
-      }
-      reader.readAsText(file)
-    },
-    [createCourseWithRelation],
-  )
-
-  const fileInputIcon = useMemo(() => {
-    if (fileInputStatus === 'saving') return <Loader size='sm' color='gray' />
-    if (fileInputStatus === 'error')
-      return (
-        <IconExclamationMark
-          color='red'
-          className='border rounded-full border-red-500'
-        />
-      )
-    if (fileInputStatus === 'saved') return <IconCircleCheck color='green' />
-
-    return <IconDownload />
-  }, [fileInputStatus])
+  const { createWithRelationCourse } = useCreateCourseWithRelation()
 
   return (
     <Layout>
       <Flex gap='sm' justify='space-between' align='center'>
         <h1>コース一覧</h1>
         <Flex gap='sm' align='center'>
-          <FileInput
-            placeholder='コースをインポート'
-            accept='.json'
-            icon={fileInputIcon}
-            classNames={{
-              // wrapper: 'border border-black rounded-md',
-              placeholder: 'text-black',
-              icon: 'text-black',
-            }}
-            error={fileInputStatus === 'error' ? true : false}
-            onChange={handleFileChange}
+          <CourseFileInput
+            createWithRelationCourse={createWithRelationCourse}
           />
           <CreateCourseButton onSubmit={createCourse} />
         </Flex>


### PR DESCRIPTION
## 詳細
- APIのバリデーションスキーマの作成
- コースのリレーションを含むデータを作成するAPIの作成
  - course/bulkの作成
  - courseに含むsectionsも同時に作成
  - sectionsに含むarticle, quizも作成
  - sectionに含むuserAgentは、既に存在したらconnectし、存在していなければ作成する
- input type="file"でJSONファイルの取得
  - parseしてJSONとして使う
  - APIを叩く
- FileInputコンポーネント・カスタムフック作成
- mutate処理

## 動作確認

- アップロードする
- コースが作成される
- コース内のセクションも作成される
![ackplfclcdccaachkaassjju9ous1aaaaazzzc](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/fe16429c-18d6-4406-aa0f-5f5a64190fd3)

- セクションの中のQuiz、Articleも作成される
- 存在しないUserAgentも作成される
![aackplfclcdccaachkaassjju9ous1aaaaazzzc](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/dec3612d-29db-4909-ace2-db82da73eaa1)
