### PR TITLE
データ削除・エディタ変更破棄の確認ダイアログ表示

### DIFF
--- a/frontend/src/components/ConfirmButton.tsx
+++ b/frontend/src/components/ConfirmButton.tsx
@@ -1,0 +1,26 @@
+import { FC, ReactNode, useCallback } from 'react'
+
+type Props = {
+  confirmMessage: string
+  onConfirm: () => void
+  children: ReactNode
+}
+
+export const ConfirmButton: FC<Props> = ({
+  confirmMessage,
+  onConfirm,
+  children,
+}) => {
+  const onClick = useCallback(() => {
+    // 確認ダイアログを表示し、OKを押すとtrueになる
+    if (window.confirm(confirmMessage)) {
+      onConfirm()
+    }
+  }, [confirmMessage, onConfirm])
+
+  return (
+    <button onClick={onClick} className='grid place-items-center'>
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/features/course/components/CourseTable.tsx
+++ b/frontend/src/features/course/components/CourseTable.tsx
@@ -4,6 +4,7 @@ import { MRT_ColumnDef, MantineReactTable } from 'mantine-react-table'
 import Link from 'next/link'
 import { FC, useMemo } from 'react'
 
+import { ConfirmButton } from '@/components/ConfirmButton'
 import { ExportJsonButton } from '@/components/ExportJsonButton'
 import { CourseWithSections } from '@/types'
 import { convertToJapanTime } from '@/utils/convertToJapanTime'
@@ -131,11 +132,12 @@ export const CourseTable: FC<Props> = ({
                 onSubmit={v => updateCourse(course.id, v)}
                 initValue={courseFormRequest}
               />
-              <IconX
-                size='1.5rem'
-                className='cursor-pointer'
-                onClick={() => deleteCourse(course.id)}
-              />
+              <ConfirmButton
+                confirmMessage={`コース: "${course.name}" を削除しますか？`}
+                onConfirm={() => deleteCourse(course.id)}
+              >
+                <IconX size='1.5rem' />
+              </ConfirmButton>
             </Flex>
           )
         },

--- a/frontend/src/features/course/components/CourseTable.tsx
+++ b/frontend/src/features/course/components/CourseTable.tsx
@@ -1,5 +1,4 @@
-import { Flex } from '@mantine/core'
-import { IconX } from '@tabler/icons-react'
+import { Button, Flex } from '@mantine/core'
 import { MRT_ColumnDef, MantineReactTable } from 'mantine-react-table'
 import Link from 'next/link'
 import { FC, useMemo } from 'react'
@@ -136,7 +135,9 @@ export const CourseTable: FC<Props> = ({
                 confirmMessage={`コース: "${course.name}" を削除しますか？`}
                 onConfirm={() => deleteCourse(course.id)}
               >
-                <IconX size='1.5rem' />
+                <Button component='span' color='red'>
+                  削除
+                </Button>
               </ConfirmButton>
             </Flex>
           )

--- a/frontend/src/features/quiz/components/QuizTable.tsx
+++ b/frontend/src/features/quiz/components/QuizTable.tsx
@@ -139,12 +139,6 @@ export const QuizTable: FC<Props> = ({ quizzes, updateQuiz, deleteQuiz }) => {
                 modalTitle='テスト編集'
                 submitButtonName='更新する'
               />
-              <IconX
-                size='1.5rem'
-                onClick={() => deleteQuiz(quiz.id)}
-                className='cursor-pointer'
-              />
-
               <ConfirmButton
                 confirmMessage={`問題: "${quiz.question}" を削除しますか？`}
                 onConfirm={() => deleteQuiz(quiz.id)}

--- a/frontend/src/features/quiz/components/QuizTable.tsx
+++ b/frontend/src/features/quiz/components/QuizTable.tsx
@@ -9,6 +9,7 @@ import {
 import { MRT_ColumnDef, MantineReactTable } from 'mantine-react-table'
 import { FC, useMemo } from 'react'
 
+import { ConfirmButton } from '@/components/ConfirmButton'
 import { convertToJapanTime } from '@/utils/convertToJapanTime'
 
 import { QuizFormModalButton } from './QuizFormModalButton'
@@ -143,6 +144,13 @@ export const QuizTable: FC<Props> = ({ quizzes, updateQuiz, deleteQuiz }) => {
                 onClick={() => deleteQuiz(quiz.id)}
                 className='cursor-pointer'
               />
+
+              <ConfirmButton
+                confirmMessage={`問題: "${quiz.question}" を削除しますか？`}
+                onConfirm={() => deleteQuiz(quiz.id)}
+              >
+                <IconX size='1.5rem' />
+              </ConfirmButton>
             </Flex>
           )
         },

--- a/frontend/src/features/quiz/components/QuizTable.tsx
+++ b/frontend/src/features/quiz/components/QuizTable.tsx
@@ -1,11 +1,6 @@
-import { Flex, List, ThemeIcon } from '@mantine/core'
+import { Button, Flex, List, ThemeIcon } from '@mantine/core'
 import { Quiz } from '@prisma/client'
-import {
-  IconArticle,
-  IconListCheck,
-  IconSelect,
-  IconX,
-} from '@tabler/icons-react'
+import { IconArticle, IconListCheck, IconSelect } from '@tabler/icons-react'
 import { MRT_ColumnDef, MantineReactTable } from 'mantine-react-table'
 import { FC, useMemo } from 'react'
 
@@ -143,7 +138,9 @@ export const QuizTable: FC<Props> = ({ quizzes, updateQuiz, deleteQuiz }) => {
                 confirmMessage={`問題: "${quiz.question}" を削除しますか？`}
                 onConfirm={() => deleteQuiz(quiz.id)}
               >
-                <IconX size='1.5rem' />
+                <Button component='span' color='red'>
+                  削除
+                </Button>
               </ConfirmButton>
             </Flex>
           )

--- a/frontend/src/features/section/components/SectionItem.tsx
+++ b/frontend/src/features/section/components/SectionItem.tsx
@@ -1,10 +1,5 @@
-import { Flex, ThemeIcon } from '@mantine/core'
-import {
-  IconArticle,
-  IconBox,
-  IconX,
-  IconCurrencyQuetzal,
-} from '@tabler/icons-react'
+import { Button, Flex, ThemeIcon } from '@mantine/core'
+import { IconArticle, IconBox, IconCurrencyQuetzal } from '@tabler/icons-react'
 import Link from 'next/link'
 import { FC } from 'react'
 
@@ -70,7 +65,9 @@ export const SectionItem: FC<Props> = ({
             confirmMessage={`セクション: "${section.name}" を削除しますか？`}
             onConfirm={() => onDelete(section.id)}
           >
-            <IconX size='1.5rem' />
+            <Button component='span' color='red'>
+              削除
+            </Button>
           </ConfirmButton>
         </Flex>
       </div>

--- a/frontend/src/features/section/components/SectionItem.tsx
+++ b/frontend/src/features/section/components/SectionItem.tsx
@@ -8,6 +8,7 @@ import {
 import Link from 'next/link'
 import { FC } from 'react'
 
+import { ConfirmButton } from '@/components/ConfirmButton'
 import { ExportJsonButton } from '@/components/ExportJsonButton'
 import { SectionWithRelation } from '@/types'
 
@@ -64,7 +65,13 @@ export const SectionItem: FC<Props> = ({
             onSubmit={v => onUpdate(section.id, v)}
             initValue={sectionFormRequest}
           />
-          <IconX size='1.5rem' onClick={() => onDelete(section.id)} />
+
+          <ConfirmButton
+            confirmMessage={`セクション: "${section.name}" を削除しますか？`}
+            onConfirm={() => onDelete(section.id)}
+          >
+            <IconX size='1.5rem' />
+          </ConfirmButton>
         </Flex>
       </div>
     </Flex>

--- a/frontend/src/features/userAgent/components/UserAgentTable.tsx
+++ b/frontend/src/features/userAgent/components/UserAgentTable.tsx
@@ -1,6 +1,6 @@
-import { Flex, ThemeIcon } from '@mantine/core'
+import { Button, Flex, ThemeIcon } from '@mantine/core'
 import { UserAgent } from '@prisma/client'
-import { IconDeviceDesktop, IconTerminal2, IconX } from '@tabler/icons-react'
+import { IconDeviceDesktop, IconTerminal2 } from '@tabler/icons-react'
 import { MRT_ColumnDef, MantineReactTable } from 'mantine-react-table'
 import { FC, useMemo } from 'react'
 
@@ -127,7 +127,9 @@ export const UserAgentTable: FC<Props> = ({
                 confirmMessage={`${userAgent.name}を削除しますか？\n※このユーザーエージェントを使用しているセクションも削除されます。`}
                 onConfirm={() => deleteUserAgent(userAgent.id)}
               >
-                <IconX size='1.5rem' />
+                <Button component='span' color='red'>
+                  削除
+                </Button>
               </ConfirmButton>
             </Flex>
           )

--- a/frontend/src/features/userAgent/components/UserAgentTable.tsx
+++ b/frontend/src/features/userAgent/components/UserAgentTable.tsx
@@ -4,6 +4,7 @@ import { IconDeviceDesktop, IconTerminal2, IconX } from '@tabler/icons-react'
 import { MRT_ColumnDef, MantineReactTable } from 'mantine-react-table'
 import { FC, useMemo } from 'react'
 
+import { ConfirmButton } from '@/components/ConfirmButton'
 import { ExportJsonButton } from '@/components/ExportJsonButton'
 import { convertToJapanTime } from '@/utils/convertToJapanTime'
 
@@ -122,11 +123,12 @@ export const UserAgentTable: FC<Props> = ({
                 onSubmit={v => updateUserAgent(userAgent.id, v)}
                 initValue={userAgentFormRequest}
               />
-              <IconX
-                size='1.5rem'
-                className='cursor-pointer'
-                onClick={() => deleteUserAgent(userAgent.id)}
-              />
+              <ConfirmButton
+                confirmMessage={`${userAgent.name}を削除しますか？\n※このユーザーエージェントを使用しているセクションも削除されます。`}
+                onConfirm={() => deleteUserAgent(userAgent.id)}
+              >
+                <IconX size='1.5rem' />
+              </ConfirmButton>
             </Flex>
           )
         },


### PR DESCRIPTION
## 詳細

以下の処理の前に確認ダイアログを出す
- データ削除
  - コース
  - セクション
  - ユーザーエージェント
  - クイズ
- エディタ編集時のブラウザバック

## 動作確認

![image](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/37b8492c-6c5b-452b-ae4d-97e690e41597)


![caccccccccccaackplfclcdccaachkaassjju9ous1aaaaazzzc](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/ad770442-1369-412d-b8ae-9635583cbb37)
