### PR TITLE
セクション・クイズのフォームに、選択したtypeを表示

### DIFF
--- a/frontend/src/features/quiz/components/quizForm/QuizForm.tsx
+++ b/frontend/src/features/quiz/components/quizForm/QuizForm.tsx
@@ -26,7 +26,7 @@ export const QuizForm: FC<Props> = ({
     return (
       <>
         <p className='text-center'>問題のタイプを選択して下さい</p>
-        <div className='mt-3 grid gap-3 grid-cols-3'>
+        <div className='mt-4 grid gap-3 grid-cols-3'>
           <div
             className='border rounded-md cursor-pointer flex flex-col bg-[#FEF5F4] shadow-md text-sm p-2 gap-1 duration-300 items-center'
             onClick={() => setQuizType('text')}

--- a/frontend/src/features/section/components/sectionForm/SectionArticleForm.tsx
+++ b/frontend/src/features/section/components/sectionForm/SectionArticleForm.tsx
@@ -57,6 +57,7 @@ export const SectionArticleForm: FC<Props> = ({
       )}
 
       <form onSubmit={handleSubmit(onSubmit)}>
+        <p className='text-center'>解説記事</p>
         <Stack>
           <TextInput
             label='セクション名'

--- a/frontend/src/features/section/components/sectionForm/SectionForm.tsx
+++ b/frontend/src/features/section/components/sectionForm/SectionForm.tsx
@@ -24,35 +24,38 @@ export const SectionForm: FC<Props> = ({
 
   if (!sectionType) {
     return (
-      <div className='text-sm grid gap-3 grid-cols-3'>
-        <div
-          className='border rounded-md cursor-pointer flex flex-col bg-[#FEF5F4] shadow-md p-2 gap-1 duration-300 items-center'
-          onClick={() => setSectionType('quiz')}
-        >
-          <ThemeIcon color='red' size='lg' variant='light' radius='md'>
-            <IconCurrencyQuetzal size='2rem' />
-          </ThemeIcon>
-          テスト
+      <>
+        <p className='text-center'>セクションのタイプを選択して下さい</p>
+        <div className='mt-4 text-sm grid gap-3 grid-cols-3'>
+          <div
+            className='border rounded-md cursor-pointer flex flex-col bg-[#FEF5F4] shadow-md p-2 gap-1 duration-300 items-center'
+            onClick={() => setSectionType('quiz')}
+          >
+            <ThemeIcon color='red' size='lg' variant='light' radius='md'>
+              <IconCurrencyQuetzal size='2rem' />
+            </ThemeIcon>
+            テスト
+          </div>
+          <div
+            className='border rounded-md cursor-pointer flex flex-col bg-[#E7F4FE] shadow-md p-2 gap-1 duration-300 items-center'
+            onClick={() => setSectionType('article')}
+          >
+            <ThemeIcon color='blue' size='lg' variant='light' radius='md'>
+              <IconArticle size='2rem' />
+            </ThemeIcon>
+            解説記事
+          </div>
+          <div
+            className='border rounded-md cursor-pointer flex flex-col bg-[#F2F0FE] shadow-md p-2 gap-1 duration-300 items-center'
+            onClick={() => setSectionType('sandbox')}
+          >
+            <ThemeIcon color='violet' size='lg' variant='light' radius='md'>
+              <IconBox size='2rem' />
+            </ThemeIcon>
+            サンドボックス
+          </div>
         </div>
-        <div
-          className='border rounded-md cursor-pointer flex flex-col bg-[#E7F4FE] shadow-md p-2 gap-1 duration-300 items-center'
-          onClick={() => setSectionType('article')}
-        >
-          <ThemeIcon color='blue' size='lg' variant='light' radius='md'>
-            <IconArticle size='2rem' />
-          </ThemeIcon>
-          解説記事
-        </div>
-        <div
-          className='border rounded-md cursor-pointer flex flex-col bg-[#F2F0FE] shadow-md p-2 gap-1 duration-300 items-center'
-          onClick={() => setSectionType('sandbox')}
-        >
-          <ThemeIcon color='violet' size='lg' variant='light' radius='md'>
-            <IconBox size='2rem' />
-          </ThemeIcon>
-          サンドボックス
-        </div>
-      </div>
+      </>
     )
   }
 

--- a/frontend/src/features/section/components/sectionForm/SectionQuizForm.tsx
+++ b/frontend/src/features/section/components/sectionForm/SectionQuizForm.tsx
@@ -57,6 +57,7 @@ export const SectionQuizForm: FC<Props> = ({
       )}
 
       <form onSubmit={handleSubmit(onSubmit)}>
+        <p className='text-center'>テスト</p>
         <Stack>
           <TextInput
             label='セクション名'

--- a/frontend/src/features/section/components/sectionForm/SectionSandboxForm.tsx
+++ b/frontend/src/features/section/components/sectionForm/SectionSandboxForm.tsx
@@ -71,6 +71,7 @@ export const SectionSandboxForm: FC<Props> = ({
       )}
 
       <form onSubmit={handleSubmit(onSubmit)}>
+        <p className='text-center'>サンドボックス</p>
         <Stack>
           <TextInput
             label='セクション名'


### PR DESCRIPTION
## 詳細

- セクションフォームに typeを選択するテキスト追加
- セクションフォーム（type選択後）に、typeを表示
- クイズフォームのtypeを選択するテキストの間隔修正

## 動作確認
![image](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/a8ac008a-c525-4b84-8e68-6e9096dc5d14)

![image](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/2bc6b670-9080-4de0-a74c-a5c865e02881)


![image](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/dc6441aa-6f07-40e9-a761-b1723f159b7f)

![image](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/60690f15-1de3-4ab6-b9e8-b6fd90dfa447)
