### PR TITLE
api/v1配下のパスは、Basic認証を不要にする

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -4,6 +4,9 @@ export function middleware(req: NextRequest) {
   const basicAuth = req.headers.get('authorization')
   const url = req.nextUrl
 
+  // api/v1/下のリクエストは認証不要にする
+  if (req.nextUrl.pathname.includes('/api/v1')) return
+
   if (basicAuth) {
     const authValue = basicAuth.split(' ')[1]
     const [userName, password] = Buffer.from(authValue, 'base64')


### PR DESCRIPTION
## 詳細
- cypas-app側からAPIを叩く時も認証が必要になるので、api/v1配下のパスはBasic認証を不要にする

## 動作確認

![aaaa](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/712ce179-0cb2-4c1e-aec1-58ffae0d6f3e)
