### PR TITLE
fix: Basic認証を/articles, /api以外のすべてのページにかける

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,27 +1,26 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
+
+// /articles/配下と/api/配下以外の全てのページにBasic認証をかける
+export const config = {
+  matcher: ['/', '/courses/:path*', '/useragents/:path'],
+}
 
 export function middleware(req: NextRequest) {
   const basicAuth = req.headers.get('authorization')
   const url = req.nextUrl
 
-  // basic認証を外す
-  return
+  if (basicAuth) {
+    const authValue = basicAuth.split(' ')[1]
+    const [userName, password] = atob(authValue).split(':')
 
-  // api/v1/下のリクエストは認証不要にする
-  // if (req.nextUrl.pathname.includes('/api/v1')) return
+    if (
+      userName === process.env.BASIC_AUTH_NAME &&
+      password === process.env.BASIC_AUTH_PASSWORD
+    ) {
+      return NextResponse.next()
+    }
+  }
+  url.pathname = '/api/auth'
 
-  // if (basicAuth) {
-  //   const authValue = basicAuth.split(' ')[1]
-  //   const [userName, password] = atob(authValue).split(':')
-
-  //   if (
-  //     userName === process.env.BASIC_AUTH_NAME &&
-  //     password === process.env.BASIC_AUTH_PASSWORD
-  //   ) {
-  //     return NextResponse.next()
-  //   }
-  // }
-  // url.pathname = '/api/auth'
-
-  // return NextResponse.rewrite(url)
+  return NextResponse.rewrite(url)
 }


### PR DESCRIPTION
## 詳細

- asic認証を/articles, /api以外のすべてのページにかける

## 動作確認

![aaaaaa](https://github.com/shin-lab-sec/cypas-cms/assets/88410576/7a9c751f-08c4-497e-b768-272b62b0e732)
